### PR TITLE
fix: Update bun version from `1.3.3` to `1.3.5`

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
         with:
-          bun-version: 1.3.3
+          bun-version: 1.3.5
       - run: bun install
       - run: bun run build
       - run: npx @vscode/vsce publish

--- a/dist/extension.js
+++ b/dist/extension.js
@@ -178,9 +178,8 @@ class JavaScriptDefinitionProvider {
         const offset = document.offsetAt(position);
         const block = findJavascriptTagBlock(text, offset);
         this.log?.(`Definition: offset=${offset} block=${block ? `${block.start}-${block.end}` : 'none'} cancelled=${token.isCancellationRequested}`);
-        if (!block || token.isCancellationRequested) {
+        if (!block || token.isCancellationRequested)
             return undefined;
-        }
         const context = text.slice(block.start, block.end);
         const jsOffset = offset - block.start;
         this.tsService.updateContent(context);

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "build": "bun x tsc -p tsconfig.json",
     "watch": "bun x tsc -w -p tsconfig.json"
   },
-  "packageManager": "bun@1.3.3",
+  "packageManager": "bun@1.3.5",
   "dependencies": {
     "typescript": "^5.9.3"
   },


### PR DESCRIPTION
This pull request updates the Bun runtime version used in both the workflow and the `package.json` to ensure consistency and take advantage of the latest bug fixes and features.

Dependency and workflow updates:

* Updated the Bun version from `1.3.3` to `1.3.5` in the GitHub Actions workflow file `.github/workflows/release-please.yml` to use the latest compatible runtime for CI/CD.
* Updated the `packageManager` field in `package.json` to `bun@1.3.5` for local development environment consistency.