### PR TITLE
fix: implement virtual file name generation and update content methods

### DIFF
--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -5,6 +5,7 @@ import type { CompletionEntry } from 'typescript';
 import type { Logger } from '../types';
 import { findJavascriptTagBlock } from '../erbBlock';
 import { TypeScriptCompletionService } from '../services/typescriptCompletionService';
+import { toVirtualFileName } from '../virtualFile';
 
 type CompletionItemData = {
   name: string;
@@ -42,7 +43,8 @@ export class JavaScriptCompletionProvider implements CompletionItemProvider {
     const lastChar = jsOffset > 0 ? jsContent[jsOffset - 1] : undefined;
     const triggerCharacter = lastChar === '.' ? '.' : undefined;
 
-    this.tsService.updateContent(jsContent);
+    const virtualFileName = toVirtualFileName(document);
+    this.tsService.updateContent(jsContent, virtualFileName);
     const completions = this.tsService.getCompletions(jsOffset, triggerCharacter);
     this.log?.(
       `Completion: jsOffset=${jsOffset} trigger=${triggerCharacter ?? 'none'} entries=${

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -6,6 +6,7 @@ import type { CancellationToken, Definition, ProviderResult, TextDocument } from
 import type { Logger } from '../types';
 import { findJavascriptTagBlock } from '../erbBlock';
 import { TypeScriptCompletionService } from '../services/typescriptCompletionService';
+import { toVirtualFileName } from '../virtualFile';
 
 export class JavaScriptDefinitionProvider implements DefinitionProvider {
   constructor(
@@ -26,7 +27,8 @@ export class JavaScriptDefinitionProvider implements DefinitionProvider {
 
     const context = text.slice(block.start, block.end);
     const jsOffset = offset - block.start;
-    this.tsService.updateContent(context);
+    const virtualFileName = toVirtualFileName(document);
+    this.tsService.updateContent(context, virtualFileName);
 
     const definitions = this.tsService.getDefinitions(jsOffset);
     this.log?.(
@@ -36,10 +38,10 @@ export class JavaScriptDefinitionProvider implements DefinitionProvider {
       return undefined;
     }
 
-    const virtualFileName = this.tsService.getVirtualFileName();
+    const serviceVirtualFileName = this.tsService.getVirtualFileName();
     const locations = definitions
       .map((definition) => {
-        if (definition.fileName === virtualFileName) {
+        if (definition.fileName === serviceVirtualFileName) {
           const start = document.positionAt(block.start + definition.textSpan.start);
           const end = document.positionAt(block.start + definition.textSpan.start + definition.textSpan.length);
           return new Location(document.uri, new Range(start, end));

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -4,6 +4,7 @@ import type { CancellationToken, ProviderResult, TextDocument } from 'vscode';
 import type { Logger } from '../types';
 import { findJavascriptTagBlock } from '../erbBlock';
 import { TypeScriptCompletionService } from '../services/typescriptCompletionService';
+import { toVirtualFileName } from '../virtualFile';
 
 export class JavaScriptHoverProvider {
   constructor(
@@ -26,7 +27,8 @@ export class JavaScriptHoverProvider {
 
     const jsContent = text.slice(block.start, block.end);
     const jsOffset = offset - block.start;
-    this.tsService.updateContent(jsContent);
+    const virtualFileName = toVirtualFileName(document);
+    this.tsService.updateContent(jsContent, virtualFileName);
 
     const info = this.tsService.getQuickInfo(jsOffset);
     this.log?.(`Hover: jsOffset=${jsOffset} info=${info ? 'yes' : 'no'} cancelled=${token.isCancellationRequested}`);

--- a/src/services/typescriptCompletionService.ts
+++ b/src/services/typescriptCompletionService.ts
@@ -14,7 +14,7 @@ import type {
 import type { Logger } from '../types';
 
 export class TypeScriptCompletionService {
-  private readonly fileName = '/virtual/erb-javascript-tag.js';
+  private fileName = '/virtual/erb-javascript-tag.js';
   private content = '';
   private version = 0;
   private readonly compilerOptions: CompilerOptions;
@@ -29,15 +29,21 @@ export class TypeScriptCompletionService {
     this.service = createLanguageService(this.#createHost());
   }
 
-  updateContent(content: string): void {
-    if (content === this.content) {
+  updateContent(content: string, fileName?: string): void {
+    const nextFileName = fileName ?? this.fileName;
+    const fileNameChanged = nextFileName !== this.fileName;
+    const contentChanged = content !== this.content;
+    if (!fileNameChanged && !contentChanged) {
       this.log?.('TypeScriptCompletionService: content unchanged');
       return;
     }
 
+    this.fileName = nextFileName;
     this.content = content;
     this.version += 1;
-    this.log?.(`TypeScriptCompletionService: content updated (version=${this.version}, length=${content.length})`);
+    this.log?.(
+      `TypeScriptCompletionService: content updated (version=${this.version}, length=${content.length}, file=${this.fileName})`
+    );
   }
 
   getCompletions(offset: number, triggerCharacter?: CompletionsTriggerCharacter): CompletionInfo | undefined {

--- a/src/virtualFile.ts
+++ b/src/virtualFile.ts
@@ -1,0 +1,16 @@
+import * as path from 'path';
+
+import type { TextDocument } from 'vscode';
+
+const VIRTUAL_PREFIX = '.erb-inline-js-helper';
+
+export function toVirtualFileName(document: TextDocument): string {
+  if (document.uri.scheme === 'file') {
+    const dir = path.dirname(document.uri.fsPath);
+    const base = path.basename(document.uri.fsPath);
+    return path.join(dir, `${VIRTUAL_PREFIX}.${base}.js`);
+  }
+
+  const safe = document.uri.toString().replace(/[^a-zA-Z0-9_.-]+/g, '_');
+  return `/virtual/${VIRTUAL_PREFIX}.${safe}.js`;
+}


### PR DESCRIPTION
This pull request updates how virtual file names are managed and passed through the TypeScript service for JavaScript blocks, improving accuracy and consistency across completion, definition, and hover providers. The main changes involve generating and using a unique virtual file name per document, updating the TypeScript service to accept this file name, and refactoring related logic to support this enhancement.

**Virtual file name management improvements:**

* Added a new utility function `toVirtualFileName` in `src/virtualFile.ts` to generate a unique virtual file name for each `TextDocument`, improving the mapping between source documents and virtual files.
* Updated `JavaScriptCompletionProvider`, `JavaScriptDefinitionProvider`, and `JavaScriptHoverProvider` to use `toVirtualFileName(document)` and pass the resulting file name to `TypeScriptCompletionService.updateContent`, ensuring each document is handled with its own virtual file context. [[1]](diffhunk://#diff-ab170680f107921de290a09f4bf2a0581fd502458efad949ba68ee3c4c80aab2R8) [[2]](diffhunk://#diff-ab170680f107921de290a09f4bf2a0581fd502458efad949ba68ee3c4c80aab2L45-R47) [[3]](diffhunk://#diff-66661d72370bcb07254f918fce998767cb377eaa5dbcf4b6980c074586764041R9) [[4]](diffhunk://#diff-66661d72370bcb07254f918fce998767cb377eaa5dbcf4b6980c074586764041L29-R31) [[5]](diffhunk://#diff-f918d8841314f1f40711bdb15df75bb4be75105da5e451897a46b9557b8b2ee0R7) [[6]](diffhunk://#diff-f918d8841314f1f40711bdb15df75bb4be75105da5e451897a46b9557b8b2ee0L29-R31)

**TypeScript service enhancements:**

* Modified `TypeScriptCompletionService` so that `updateContent` accepts an optional `fileName` parameter, updates the internal file name if it changes, and logs the file name in updates. This ensures the language service works with the correct virtual file per document. [[1]](diffhunk://#diff-fdd5ef97ecf21a015eedf2acd6261b014db0f01d5453d7f5406c3a20b65cb7a0L17-R17) [[2]](diffhunk://#diff-fdd5ef97ecf21a015eedf2acd6261b014db0f01d5453d7f5406c3a20b65cb7a0L32-R46)
* Refactored variable naming in `JavaScriptDefinitionProvider` to clarify the distinction between the current virtual file name and the one used by the TypeScript service.